### PR TITLE
Update preamble for firmware 1.40.0a

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -52,7 +52,7 @@ func yamahaManufacturerCode() [3]byte {
 
 // mystery stuff that gets send with every command
 func preamble() [3]byte {
-	return [3]byte{0x22, 0x02, 0x4d}
+	return [3]byte{0x24, 0x00, 0x4d}
 }
 
 func sequenceNumber(seqNum uint32) byte {

--- a/messages.go
+++ b/messages.go
@@ -8,6 +8,7 @@ import (
 // These commands will set-up the connection to allow other commands to work correctly (e.g. SetPreset)
 var Init = message.MessageSet{
 	// ??
+	&message.RawMessage{Data: []byte{0xf0, 0xf7, 0x00}},
 	&message.RawMessage{Data: []byte{0xf0, 0x7e, 0x7f, 0x06, 0x01, 0xf7}},
 	&message.THRMessage{
 		Type:        message.TypeOne,


### PR DESCRIPTION
Latest firmware has a different version. Hex dump for the reference:

```hex
0000   f0 00 01 0c 24 00 4d 00 01 00 00 0b 00 01 00 00
0010   00 04 00 00 00 00 00 00 00 00 00 00 f7
```